### PR TITLE
Improve show title similarity evaluation

### DIFF
--- a/src/win_scanly/processor.py
+++ b/src/win_scanly/processor.py
@@ -77,6 +77,11 @@ def process_file(
         ai_data = {"raw": path.name, "sanitised_guess": path.stem}
 
     guess = _safe_str(ai_data.get("sanitised_guess", path.stem))
+    title_tokens = ai_data.get("title_tokens")
+    if isinstance(title_tokens, list) and title_tokens:
+        primary_title = _safe_str(title_tokens[0])
+    else:
+        primary_title = guess
     year_hint = ai_data.get("year_hint")
     season_hint = ai_data.get("season_hint")
     episode_hint = ai_data.get("episode_hint")
@@ -95,10 +100,11 @@ def process_file(
             candidate_year=movie_result.year,
         )
         sim_show = evaluate_match(
-            guess,
+            primary_title,
             _safe_str(show_result.title),
             query_year=year_hint,
             candidate_year=show_result.year,
+            folder_hint=_safe_str(path.parent.name),
         )
         if sim_movie["score"] >= sim_show["score"]:
             best_result, best_type, similarity_info = movie_result, "movie", sim_movie
@@ -115,10 +121,11 @@ def process_file(
     elif show_result:
         best_result, best_type = show_result, "show"
         similarity_info = evaluate_match(
-            guess,
+            primary_title,
             _safe_str(show_result.title),
             query_year=year_hint,
             candidate_year=show_result.year,
+            folder_hint=_safe_str(path.parent.name),
         )
 
     if not best_result or not similarity_info or not similarity_info["accepted"]:


### PR DESCRIPTION
## Summary
- use the AI parser's primary title token when scoring TV matches against TMDB results
- provide folder context to the similarity evaluator so show matches gain additional signal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e60e455488832ebb92af2b05cebe3b