### PR TITLE
Relocate Windows pipeline env into module scope

### DIFF
--- a/src/win_scanly/.env
+++ b/src/win_scanly/.env
@@ -1,0 +1,54 @@
+# ==============================
+# ⚙️  SCANLY vNext — Production Configuration
+# ==============================
+
+# --- 🧠 TMDB API ---
+TMDB_API_KEY=
+
+# --- 🤖 AI / LLM Parser (Ollama Local Model) ---
+AI_ENABLED=true
+AI_MODEL=gemma2:2b
+AI_TIMEOUT_SECONDS=15
+OLLAMA_URL=http://localhost:11434/api/generate
+OLLAMA_PORT=11434
+# Full path to Ollama executable
+OLLAMA_PATH=C:\zurgrclone\Ollama\ollama.exe
+
+# --- 🗂️ File System Layout ---
+# Primary scan source (rclone-mounted or local media root)
+SOURCE_DIR=R:\__all__
+
+# Destination directories (writeable targets)
+DEST_MOVIES_DIR=C:\zurgrclone\libraries\movies
+DEST_SHOWS_DIR=C:\zurgrclone\libraries\shows
+DEST_UNMATCHED_DIR=C:\zurgrclone\libraries\_Unmatched
+
+# --- 🧩 Regex / Matching Layer ---
+# Regex-first layer is always active by default.
+# Uncomment to disable manually (not recommended):
+# USE_REGEX_FIRST=false
+
+# --- 🔁 Scanning Parameters ---
+# Scan every 5 minutes for new or changed files
+SCAN_INTERVAL_SECONDS=300
+# Supported file extensions
+ALLOWED_EXTENSIONS=.mp4,.mkv,.avi,.mov,.m4v,.ts,.wmv
+
+# --- 🧹 Filename Normalization ---
+# Regex tags to strip from filenames before TMDB/AI parsing
+RENAME_TAGS=(?i)(^|[ ._\-\[\(])(?:WEB[ ._-]?DL|WEBRip|Blu[ ._-]?Ray|x264|x265|1080p|720p)(?=$|[ ._\-\]\),])
+# Path for incremental scan state tracking
+STATE_FILE=data/state.json
+
+# --- 🪵 Logging & Diagnostics ---
+LOG_LEVEL=INFO
+AI_LOG_LEVEL=INFO
+# Optional: increase verbosity for testing only
+# LOG_LEVEL=DEBUG
+
+# Path to ffprobe (for media duration validation)
+FFPROBE_PATH=ffprobe
+
+# ==============================
+# ✅  End of Configuration (Production)
+# ==============================

--- a/src/win_scanly/config.py
+++ b/src/win_scanly/config.py
@@ -15,9 +15,14 @@ from dotenv import load_dotenv
 logger = logging.getLogger(__name__)
 
 # Load .env either from project root or current working directory.
-_ENV_PATH_CANDIDATES: Tuple[Path, ...] = (
-    Path(__file__).resolve().parents[2] / ".env",
-    Path.cwd() / ".env",
+_ENV_PATH_CANDIDATES: Tuple[Path, ...] = tuple(
+    dict.fromkeys(
+        (
+            Path(__file__).resolve().with_name(".env"),
+            Path(__file__).resolve().parents[2] / ".env",
+            Path.cwd() / ".env",
+        )
+    )
 )
 for candidate in _ENV_PATH_CANDIDATES:
     if candidate.exists():


### PR DESCRIPTION
## Summary
- move the Windows-specific production `.env` alongside `src/win_scanly` and trim it to the requested template values
- update the win_scanly configuration loader to consider the module-local `.env` before falling back to repo root or cwd

## Testing
- pytest tests/test_win_scanly.py

------
https://chatgpt.com/codex/tasks/task_e_68e6daa94cb0832e8d2e7b9fb07f08a5